### PR TITLE
(MODULES-5738) Restore functionality on Windows

### DIFF
--- a/spec/acceptance/nodesets/windows2012r2-pooler.yml
+++ b/spec/acceptance/nodesets/windows2012r2-pooler.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  windows2012r2:
+    roles:
+      - agent
+      - default
+    platform: windows-2012r2-64
+    ruby_arch: x64
+    template: win-2012r2-x86_64
+    hypervisor: vmpooler
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,7 +10,7 @@ install_bolt_on(hosts) unless pe_install?
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 
-UNSUPPORTED_PLATFORMS = %w[Windows Solaris AIX].freeze
+UNSUPPORTED_PLATFORMS = %w[Solaris AIX].freeze
 
 RSpec.configure do |c|
   # Readable test descriptions

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -5,16 +5,24 @@ require 'json'
 require 'open3'
 
 def get(fact)
-  if ENV.key? 'Path'
-    facter = '"C:\Program Files\Puppet Labs\Puppet\bin\facter"'
-    ENV['Path'].split(';').each do |e|
-      if %r{Puppet\\bin} =~ e
-        facter = "\"#{e}\\facter\""
+  if Gem.win_platform?
+    require 'win32/registry'
+    begin
+      installed_dir = Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+        dir = reg['RememberedInstallDir64']
+        break dir if File.exist?(dir)
+        reg['RememberedInstallDir']
       end
+      facter = File.join(installed_dir, 'bin', 'facter.bat')
+    rescue Win32::Registry::Error
+      facter = ''
     end
   else
     facter = '/opt/puppetlabs/puppet/bin/facter'
   end
+
+  # Fall back to PATH lookup if puppet-agent isn't installed
+  facter = 'facter' unless File.exist?(facter)
 
   stdout, stderr, status = Open3.capture3(facter, '-p', fact)
   raise Puppet::Error, stderr if status != 0


### PR DESCRIPTION
A previous commit to fix how we invoked facter broke because we didn't
remove quotes on the path. Do so now.