### PR TITLE
(MODULES-6955) Modify output, make fact param optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,14 @@ This will now download a pre-fabricated image configured in the [default node-se
 install Puppet, copy this module, and install its dependencies per [spec/spec_helper_acceptance.rb](./spec/spec_helper_acceptance.rb)
 and then run all the tests under [spec/acceptance](./spec/acceptance).
 
+A specific node set can be selected by setting the `BEAKER_set` environment variable
+
+```shell
+% export BEAKER_set=spec/acceptance/nodesets/centos-7-x64
+```
+
+If using a VM pooler node set, a password must be set via `BEAKER_password`.
+
 ## Writing Tests
 
 ### Unit Tests

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -7,10 +7,33 @@ describe 'facter_task task' do
 
   describe 'puppet facts' do
     it 'get a puppet fact' do
-      result = run_task(task_name: 'facter_task', params: 'fact=osfamily')
-      expect_multiple_regexes(result: result, regexes: [%r{status.*#{os_family_fact}}, %r{Job completed. 1/1 nodes succeeded|Ran on 1 node}])
-      result = run_task(task_name: 'facter_task', params: 'fact=operatingsystem')
-      expect_multiple_regexes(result: result, regexes: [%r{status.*#{operating_system_fact}}, %r{Job completed. 1/1 nodes succeeded|Ran on 1 node}])
+      result = run_task(task_name: 'facter_task', params: 'fact=osfamily', format: 'json')
+      expect(result['status']).to eq('success')
+      expect(result['result']).to eq('osfamily' => os_family_fact)
+      result = run_task(task_name: 'facter_task', params: 'fact=operatingsystem', format: 'json')
+      expect(result['status']).to eq('success')
+      expect(result['result']).to eq('operatingsystem' => operating_system_fact)
+    end
+
+    it 'get a structured fact' do
+      result = run_task(task_name: 'facter_task', params: 'fact=os', format: 'json')
+      expect(result['status']).to eq('success')
+      expect(result['result']).to include('os')
+      expect(result['result']['os']['family']).to eq(os_family_fact)
+      expect(result['result']['os']['name']).to eq(operating_system_fact)
+    end
+
+    it 'gets all facts' do
+      result = run_task(task_name: 'facter_task', format: 'json')
+      expect(result['status']).to eq('success')
+      expect(result['result']).to include('os', 'networking', 'kernel')
+    end
+
+    it 'fails cleanly' do
+      result = run_task(task_name: 'facter_task', params: 'fact=--foo', format: 'json')
+      expect(result['status']).to eq('failure')
+      expect(result['result']['_error']).to eq('kind' => 'facter_task/failure',
+                                               'msg' => "error: unrecognised option '--foo'\n")
     end
   end
 end

--- a/spec/acceptance/nodesets/centos7-pooler.yml
+++ b/spec/acceptance/nodesets/centos7-pooler.yml
@@ -1,9 +1,6 @@
 HOSTS:
   rhel7:
     roles:
-      - master
-      - dashboard
-      - database
       - agent
       - default
     platform: el-7-x86_64

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -4,7 +4,7 @@
   "parameters": {
     "fact": {
       "description": "The name of the fact to retrieve",
-      "type": "String"
+      "type": "Optional[String]"
     }
   }
 }


### PR DESCRIPTION
Makes the fact param optional. If not provided, returns all facts.

Also changes output to return raw `facter -p --json` output so task
runner can read as json, and use `_error` form for failures.