### PR TITLE
(MODULES-7419) Find facter via registry on 32-bit Windows

### DIFF
--- a/spec/acceptance/nodesets/windows10ent32-pooler.yml
+++ b/spec/acceptance/nodesets/windows10ent32-pooler.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  windows10ent:
+    roles:
+      - agent
+      - default
+    platform: windows-10ent-32
+    ruby_arch: x86
+    template: win-10-ent-i386
+    hypervisor: vmpooler
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  type: foss

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,6 +1,5 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
-require 'puppet'
 require 'json'
 require 'open3'
 

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -9,8 +9,10 @@ def get(fact)
     require 'win32/registry'
     begin
       installed_dir = Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
-        dir = reg['RememberedInstallDir64']
-        break dir if File.exist?(dir)
+        if reg.keys.include?('RememberedInstallDir64')
+          dir = reg['RememberedInstallDir64']
+          break dir if File.exist?(dir)
+        end
         reg['RememberedInstallDir']
       end
       facter = File.join(installed_dir, 'bin', 'facter.bat')


### PR DESCRIPTION
Previously if the lookup for 64-bit registry keys failed it would not
fallback to the 32-bit key. Now it skips the 64-bit registry key if it's
not present and tries the 32-bit key.