### PR TITLE
(MODULES-7419) Fix registry lookup and avoid BOLT-698

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -32,8 +32,10 @@ describe 'facter_task task' do
     it 'fails cleanly' do
       result = run_task(task_name: 'facter_task', params: 'fact=--foo', format: 'json')
       expect(result['status']).to eq('failure')
-      expect(result['result']['_error']).to eq('kind' => 'facter_task/failure',
-                                               'msg' => "error: unrecognised option '--foo'\n")
+      expect(result['result']['_error']['kind']).to eq('facter_task/failure')
+      expect(result['result']['_error']['msg']).to match(
+        %r{Exit 1 running .*bin/facter.* -p --json --foo: error: unrecognised option '--foo'},
+      )
     end
   end
 end

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -48,8 +48,8 @@ params = JSON.parse(STDIN.read)
 fact = params['fact']
 
 begin
-  result = get(fact)
-  puts result
+  result = JSON.parse(get(fact))
+  puts result.to_json
   exit 0
 rescue => e
   puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -40,7 +40,7 @@ def get(fact)
   cmd = [facter, '-p', '--json']
   cmd << fact if fact
   stdout, stderr, status = Open3.capture3(*cmd)
-  raise stderr if status != 0
+  raise "Exit #{status.exitstatus} running #{cmd.join(' ')}: #{stderr}" if status != 0
   stdout
 end
 


### PR DESCRIPTION
Fix registry lookup. The previous commit worked for 32-bit Windows, but broke 64-bit Windows.

Also improve error output, ensure the result is valid JSON, and work around BOLT-698.