### PR TITLE
(FM-8275) Add vagrant provision list

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -11,6 +11,9 @@ travis_el6:
 travis_el7:
   provisioner: docker
   images: ['centos:7', 'oraclelinux:7', 'scientificlinux/sl:7']
+vagrant:
+  provisioner: vagrant
+  images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
 release_checks:
   provisioner: vmpooler
   images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-x86_64', 'win-2019-x86_64', 'win-10-pro-x86_64']


### PR DESCRIPTION
Prior to this commit the only provisioners included in
the provision lists were docker and vmpooler, neither
of which are particularly accessible to folks developing
on Windows outside of Puppet.

This commit adds a list which leverages the vagrant
provisioner.