### PR TITLE
pdksync - remove deploy to forge from travis

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,8 +7,6 @@
   unmanaged: true
 
 .travis.yml:
-  user: puppet
-  secure: ""
   branches:
     - release
   includes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,12 +104,3 @@ branches:
     - release
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
-gem 'pdk', git: 'https://github.com/puppetlabs/pdk.git', branch: 'master'
 
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}

--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,7 @@
     }
   ],
   "description": "Tasks that inspect the value of system facts",
-  "pdk-version": "1.14.0",
+  "pdk-version": "1.14.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g0b5b39b"
+  "template-ref": "heads/master-0-g1a92949"
 }


### PR DESCRIPTION
remove deploy to forge from travis
pdk version: `1.14.1` 
