### PR TITLE
(maint) MODULES-10104 - Update PDK Templates to faf9e8b and disable forge deploy

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,8 @@
   unmanaged: true
 
 .travis.yml:
+  deploy_to_forge:
+    enabled: false
   branches:
     - release
   includes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ stages:
   - static
   - spec
   - acceptance
-  -
-    if: tag =~ ^v\d
-    name: deploy
 matrix:
   fast_finish: true
   include:

--- a/metadata.json
+++ b/metadata.json
@@ -68,5 +68,5 @@
   "description": "Tasks that inspect the value of system facts",
   "pdk-version": "1.14.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g1a92949"
+  "template-ref": "heads/master-0-gfaf9e8b"
 }


### PR DESCRIPTION
Previously in commit e791c643c0df338 the travis CI config file was manually
changed to stop automated deployments as this module is not configured for them.
Now that the PDK Templates have been updated with this facility, this commit
updates the sync.yaml and runs a pdk update at pdk-template commit faf9e8b.
Therefore future PDK updates will not re-instate the deployment phases.