### PR TITLE
(MODULES-10833) Add support for puppet facts show

### DIFF
--- a/lib/facts.rb
+++ b/lib/facts.rb
@@ -1,0 +1,78 @@
+require 'open3'
+require 'json'
+
+require_relative 'platform'
+
+# Gathers facts taking into account different combinations of puppet and facter,
+# because fact gathering in done differently depending on puppet and facter versions
+class Facts
+  def initialize
+    @platform = Platform.new
+    @facter_executable = @platform.facter_path
+    @puppet_executable = @platform.puppet_path
+  end
+
+  # Resolves fact on the system, if a specific fact is given,
+  # it will only resolve that fact,
+  # otherwise it will resolve all facts
+  def resolve(fact)
+    facts_command = determine_facts_command
+    facts_command << fact if fact
+
+    begin
+      stdout, stderr, status = Open3.capture3(*facts_command)
+      raise "Exit #{status.exitstatus} running #{facts_command}: #{stderr}" if status != 0
+
+      result = parse(stdout)
+      puts result
+      exit 0
+    rescue => e
+      puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)
+      exit 1
+    end
+  end
+
+  private
+
+  # Determine the command tht will be used to gather facts,
+  # this depends on facter version and on puppet version
+  def determine_facts_command
+    facter_version = component_version(@facter_executable)
+
+    if facter_version =~ %r{^[0-2]\.}
+      [@facter_executable, '-p', '--json']
+    elsif facter_version =~ %r{^3\.}
+      [@facter_executable, '-p', '--json', '--show-legacy']
+    else
+      # facter 4
+      determine_command_for_facter_4
+    end
+  end
+
+  def parse(json_string)
+    result = JSON.parse(json_string)
+    result.to_json
+  end
+
+  # Supported components are facter and puppet,
+  # but it can be any executable that supports --version argument
+  def component_version(exec)
+    stdout, _stderr, _status = Open3.capture3(exec, '--version')
+
+    stdout.strip
+  end
+
+  # Starting with facter 4 and puppet 7, `facter -p` and `facter --puppet`
+  # have been replaced by `puppet facts show`
+  def determine_command_for_facter_4
+    puppet_version = component_version(@puppet_executable)
+
+    if puppet_version =~ %r{^6\.}
+      # puppet 6 with facter 4
+      [@facter_executable, '--json', '--show-legacy']
+    else
+      # puppet 7 with facter 4
+      [@puppet_executable, 'facts', 'show', '--show-legacy']
+    end
+  end
+end

--- a/lib/platform.rb
+++ b/lib/platform.rb
@@ -1,0 +1,51 @@
+# Used for detecting facter and puppet paths based
+# on the platform we are running on.
+class Platform
+  def initialize
+    if Gem.win_platform?
+      require 'win32/registry'
+      @installed_dir =
+        begin
+          Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+            # rubocop:disable Style/RescueModifier
+            # Rescue missing key
+            dir = reg['RememberedInstallDir64'] rescue ''
+            # Both keys may exist, make sure the dir exists
+            break dir if File.exist?(dir)
+
+            # Rescue missing key
+            reg['RememberedInstallDir'] rescue ''
+            # rubocop:enable Style/RescueModifier
+          end
+        rescue Win32::Registry::Error
+          # Rescue missing registry path
+          ''
+        end
+
+      @platform = :windows_like
+    else
+      @installed_dir = '/opt/puppetlabs/puppet/bin'
+      @platform = :linux_like
+    end
+  end
+
+  def facter_path
+    return 'facter' unless File.exist?(@installed_dir)
+
+    if @platform == :linux_like
+      File.join(@installed_dir, 'facter')
+    else
+      File.join(@installed_dir, 'bin', 'facter.bat')
+    end
+  end
+
+  def puppet_path
+    return 'puppet' unless File.exist?(@installed_dir)
+
+    if @platform == :linux_like
+      File.join(@installed_dir, 'puppet')
+    else
+      File.join(@installed_dir, 'bin', 'puppet.bat')
+    end
+  end
+end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,6 +1,7 @@
 {
   "description": "Inspect the value of system facts",
   "input_method": "stdin",
+  "files": ["facter_task/lib/facts.rb", "facter_task/lib/platform.rb"],
   "parameters": {
     "fact": {
       "description": "The name of the fact to retrieve",

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,57 +1,9 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
-require 'json'
-require 'open3'
-
-def get(fact)
-  if Gem.win_platform?
-    require 'win32/registry'
-    installed_dir =
-      begin
-        Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
-          # rubocop:disable Style/RescueModifier
-          # Rescue missing key
-          dir = reg['RememberedInstallDir64'] rescue ''
-          # Both keys may exist, make sure the dir exists
-          break dir if File.exist?(dir)
-
-          # Rescue missing key
-          reg['RememberedInstallDir'] rescue ''
-          # rubocop:enable Style/RescueModifier
-        end
-      rescue Win32::Registry::Error
-        # Rescue missing registry path
-        ''
-      end
-
-    facter =
-      if installed_dir.empty?
-        ''
-      else
-        File.join(installed_dir, 'bin', 'facter.bat')
-      end
-  else
-    facter = '/opt/puppetlabs/puppet/bin/facter'
-  end
-
-  # Fall back to PATH lookup if puppet-agent isn't installed
-  facter = 'facter' unless File.exist?(facter)
-
-  cmd = [facter, '-p', '--json']
-  cmd << fact if fact
-  stdout, stderr, status = Open3.capture3(*cmd)
-  raise "Exit #{status.exitstatus} running #{cmd.join(' ')}: #{stderr}" if status != 0
-  stdout
-end
+require_relative '../lib/facts'
 
 params = JSON.parse(STDIN.read)
 fact = params['fact']
 
-begin
-  result = JSON.parse(get(fact))
-  puts result.to_json
-  exit 0
-rescue => e
-  puts({ _error: { kind: 'facter_task/failure', msg: e.message } }.to_json)
-  exit 1
-end
+facts = Facts.new
+facts.resolve(fact)


### PR DESCRIPTION
'facter -p' and 'facter --facts' have been replaced by puppet facts show starting with Puppet 7. 

The changes take into account facter and puppet versions when determining what command to use to gather facts from the system.

