### PR TITLE
pdksync - (MAINT) Remove RHEL 5 family support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -28,7 +27,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -36,7 +34,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"


### PR DESCRIPTION
(MAINT) Remove RHEL 5 family support
pdk version: `1.18.1` 
