### PR TITLE
pdksync - (IAC-1719) - Add Support for Debian 10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
(IAC-1719) - Add Support for Debian 10
pdk version: `2.1.0` 
