### PR TITLE
pdksync - (GH-iac-335) Remove Support for Ubuntu 16.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,6 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04",
         "18.04",
         "20.04"
       ]


### PR DESCRIPTION
(GH-iac-335) Remove Support for Ubuntu 16.04
pdk version: `2.3.0` 
