### PR TITLE
(MAINT) Remove references to beaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,15 @@ For information on the classes and types, see the [REFERENCE.md](https://github.
 
 ## Limitations
 
-To run acceptance tests against Windows machines locally, ensure that the `BEAKER_password` environment variable has been set to the password of the Administrator user of the target machine.
-
 For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-facter_task/blob/main/metadata.json)
 
 ## Development
 
-Acceptance tests for this module leverage [puppet_litmus](https://github.com/puppetlabs/puppet_litmus).
+Acceptance tests are ran using [puppet_litmus](https://github.com/puppetlabs/puppet_litmus).
 To run the acceptance tests follow the instructions [here](https://github.com/puppetlabs/puppet_litmus/wiki/Tutorial:-use-Litmus-to-execute-acceptance-tests-with-a-sample-module-(MoTD)#install-the-necessary-gems-for-the-module).
 You can also find a tutorial and walkthrough of using Litmus and the PDK on [YouTube](https://www.youtube.com/watch?v=FYfR7ZEGHoE).
 
-If you run into an issue with this module, or if you would like to request a feature, please [file a ticket](https://tickets.puppetlabs.com/browse/MODULES/).
-Every Monday the Puppet IA Content Team has [office hours](https://puppet.com/community/office-hours) in the [Puppet Community Slack](http://slack.puppet.com/), alternating between an EMEA friendly time (1300 UTC) and an Americas friendly time (0900 Pacific, 1700 UTC).
+If you run into an issue with this module, or if you would like to request a feature, please file a ticket on the issues tab.
 
 If you have problems getting this module up and running, please [contact Support](http://puppetlabs.com/services/customer-support).
 


### PR DESCRIPTION
Prior to this commit the README referenced usage of beaker. 

I have removed all references to beaker as it is no longer used or relevant for our test infrastructure.